### PR TITLE
refactor: use `std::sync::LazyLock` instead of `once_cell`'s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ maintenance = { status = "actively-maintained" }
 
 [dependencies]
 byteorder = "1.4.3"
-once_cell = "1.17.0"
 twox-hash = { version = "1.6.3", default-features = false }
 uuid = "1.2.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,17 +44,17 @@
 )] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
 #![allow(clippy::must_use_candidate)]
 
-use once_cell::sync::Lazy;
 use std::{
     any::TypeId,
     env,
     fs::File,
     hash::{Hash, Hasher},
     io,
+    sync::LazyLock,
 };
 use uuid::Uuid;
 
-static BUILD_ID: Lazy<Uuid> = Lazy::new(calculate);
+static BUILD_ID: LazyLock<Uuid> = LazyLock::new(calculate);
 
 /// Returns a [Uuid] uniquely representing the build of the current binary.
 ///


### PR DESCRIPTION
Removes the dependency on `once_cell`, but bumps the MSRV to 1.80.0.

I believe this is the only usage of `once_cell` in [laze](https://github.com/kaspar030/laze) (except for one dev-dependency).

---

`cargo test` tests still pass.